### PR TITLE
Add: Improve game restart flow, move button interaction + html spacing + css styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -126,7 +126,6 @@ background-color: #A66500;
     margin-left: 0.25rem;
 }
 
-
 .section-title, .section-description {
     color: white !important;
 }
@@ -165,6 +164,14 @@ background-color: #A66500;
     margin: 2px !important;
 }
 
+.selected-move-btn img {
+    width: 350px !important;
+    height: 350px !important;
+    font-size: 2rem;
+    z-index: 2;
+    transition: all 0.2s ease-in-out;
+}
+
 .scoreTxt {
     font-family: var(--secondary-font);
     font-size: 1.5rem;
@@ -186,6 +193,11 @@ background-color: #A66500;
     font-size: 4rem;
     font-weight: bold;
     text-align: center;
+    z-index: 3;
+}
+
+#game-state-message {
+    color: white;
 }
 
 /* Solid color for selected difficulty buttons */

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
         <img src="assets/images/HeaderV2.webp" alt="Spock It To Me Western Town game header image"
             class="img-fluid headerImage">
     </header>
+
     <!-- Centered Instructions Modal Trigger Button -->
     <div class="d-flex justify-content-center mt-2">
         <div class="d-flex justify-content-center mt-2">
@@ -25,6 +26,7 @@
             </button>
         </div>
     </div>
+
     <!-- Instructions Modal -->
     <div class="modal fade" id="instructionsModal" tabindex="-1" aria-labelledby="instructionsModalLabel"
         aria-modal="true" role="dialog" aria-describedby="instructionsModalDesc">
@@ -186,6 +188,7 @@
             </div>
         </div>
     </div>
+
     <!-- Countdown Display (appears dynamically) -->
     <div id="countdown-timer-container" class="d-flex justify-content-center"></div>
     <main class="container my-4" id="main-content" role="main">
@@ -255,6 +258,7 @@
                 </div>
             </section>
         </div>
+
         <!-- Start/Stop, Score, and Modal Buttons Responsive Row -->
         <div class="container my-4" aria-label="Game controls and score">
             <div class="row g-3 align-items-center text-center">
@@ -284,6 +288,7 @@
                 </div>
             </div>
         </div>
+
         <!-- Difficulty Modal -->
         <div class="modal fade" id="difficultyModal" tabindex="-1" aria-labelledby="difficultyModalLabel"
             aria-modal="true" role="dialog" aria-describedby="difficultyModalDesc">
@@ -346,6 +351,7 @@
                 </div>
             </div>
         </div>
+
         <!-- Best Of Modal -->
         <div class="modal fade" id="bestOfModal" tabindex="-1" aria-labelledby="bestOfModalLabel" aria-modal="true"
             role="dialog" aria-describedby="bestOfModalDesc">
@@ -391,6 +397,7 @@
         <div class="text-center mt-4">
             <h2 id="game-state-message" class="mt-3"></h2>
         </div>
+
         <div id="browser-console"
             style="background:#222;color:#eee;padding:1em;font-family:monospace;max-height:200px;overflow:auto;"></div>
     </main>


### PR DESCRIPTION
The Restart button logic was updated so it resets the game to the initial state, allowing you to change "Best Of" and "Difficulty" before starting a new game, instead of locking you into the previous settings.
The move selection logic was updated so that, after a user picks a move, the selected button cannot be interacted with until the next round. This was achieved using pointer-events: none and [tabIndex = -1], so the button does not look disabled but is not clickable or focusable.